### PR TITLE
proprietary: remove some uneeded blobs

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -371,7 +371,6 @@ vendor/etc/plmn_delta_usagsm.bin
 vendor/etc/plmn_se13.bin
 vendor/lib/libaudio-ril.so
 vendor/lib/libmdf.so
-vendor/lib/libpa.so
 vendor/lib/libreference-ril.so
 vendor/lib/libril.so
 vendor/lib/librilutils.so
@@ -380,14 +379,12 @@ vendor/lib/libsec-ril-dsds.so
 vendor/lib/libsec_semRil.so
 vendor/lib/libsecure_storage.so
 vendor/lib/libvndsecril-client.so
-vendor/lib/vendor.samsung.hardware.security.proca@2.0.so
 vendor/lib/vendor.samsung.hardware.security.securestorage@3.0.so
 vendor/lib/vendor.samsung.hardware.radio.bridge@2.0.so
 vendor/lib/vendor.samsung.hardware.radio.channel@2.0.so
 vendor/lib/vendor.samsung.hardware.radio@2.0.so
 vendor/lib/vendor.samsung.hardware.radio@2.1.so
 vendor/lib64/libmdf.so
-vendor/lib64/libpa.so
 vendor/lib64/libreference-ril.so
 vendor/lib64/libril.so
 vendor/lib64/librilutils.so
@@ -396,7 +393,6 @@ vendor/lib64/libsec-ril-dsds.so
 vendor/lib64/libsec_semRil.so
 vendor/lib64/libsecure_storage.so
 vendor/lib64/libvndsecril-client.so
-vendor/lib64/vendor.samsung.hardware.security.proca@2.0.so
 vendor/lib64/vendor.samsung.hardware.security.securestorage@3.0.so
 vendor/lib64/vendor.samsung.hardware.radio.bridge@2.0.so
 vendor/lib64/vendor.samsung.hardware.radio.channel@2.0.so

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -84,15 +84,8 @@ system/lib64/libsomxwmv8d.so
 
 ### RIL
 init.rilmptcp.rc:system/etc/init/init.rilmptcp.rc
-system/bin/connfwexe
-system/bin/ddexe
 system/bin/eris
 system/bin/ikev2-client
-system/bin/redsocks
-system/bin/smdexe
-system/etc/init/init.rilcarrier.rc
-system/etc/init/init.rilchip.rc
-system/etc/init/init.rilcommon.rc
 system/etc/init/init.rilepdg.rc
 system/etc/eris.conf
 system/etc/restart_radio_process.sh
@@ -101,13 +94,11 @@ system/lib/libfactoryutil.so
 system/lib/libfloatingfeature.so
 system/lib/libmdf.so
 system/lib/libomission_avoidance.so
-system/lib/libpa.so
 system/lib/libpacm_client.so
 system/lib/libsecnativefeature.so
 system/lib/libsecril-client.so
 system/lib/libsecure_storage.so
 system/lib/libsec_semRil.so
-system/lib/vendor.samsung.hardware.security.proca@2.0.so
 system/lib/vendor.samsung.hardware.security.securestorage@3.0.so
 system/lib64/libatparser.so
 system/lib64/libfactoryutil.so
@@ -117,13 +108,11 @@ system/lib64/liberis_strongswan.so
 system/lib64/libfloatingfeature.so
 system/lib64/libmdf.so
 system/lib64/libomission_avoidance.so
-system/lib64/libpa.so
 system/lib64/libpacm_client.so
 system/lib64/libsecnativefeature.so
 system/lib64/libsecril-client.so
 system/lib64/libsecure_storage.so
 system/lib64/libsec_semRil.so
-system/lib64/vendor.samsung.hardware.security.proca@2.0.so
 system/lib64/vendor.samsung.hardware.security.securestorage@3.0.so
 
 ### SAMSUNG_SLSI_CONFIGSTORE

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -36,7 +36,7 @@ system/media/water_protection_usb.spi
 system/etc/init/init.gpscommon.rc
 
 ### NFC
-system/etc/libnfc-nci.conf
+system/etc/libnfc-nci.conf:vendor/etc/libnfc-nci.conf
 system/lib64/vendor.samsung.hardware.nfc@2.0.so
 
 ### OMX


### PR DESCRIPTION
Is it ok now? service definitions for eris and ikev2-client are inside init.rilmptcp.rc and init.rilepdg.rc which I left in.