### PR TITLE
exynos9820: enable support for extended length nfc

### DIFF
--- a/proprietary-files-vendor.txt
+++ b/proprietary-files-vendor.txt
@@ -264,7 +264,6 @@ vendor/lib64/libkeymaster_helper_vendor.so
 ### NFC
 vendor/bin/hw/sec.android.hardware.nfc@1.2-service
 vendor/etc/init/sec.android.hardware.nfc@1.2-service.rc
-vendor/etc/libnfc-sec-vendor.conf
 vendor/firmware/nfc/sec_s3nrn82_firmware.bin
 vendor/lib64/nfc_nci_sec.so
 vendor/lib64/vendor.samsung.hardware.nfc@2.0.so


### PR DESCRIPTION
See https://github.com/whatawurst/android_device_samsung_exynos9820-common/pull/159